### PR TITLE
Google Analytics reporting functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /nbproject/
+.idea/

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ is loaded:
 <script>
     // Include analytics.js/tag-manager js here...
     
+    ga('create', '<trackingId>'); // New tracker instance
+    
     <?= Test::getGoogleAnalyticsExperimentJsContent() ?>
 </script>
 ```
@@ -263,12 +265,16 @@ Continuing this example, if the chosen variation was variation 'c' it would resu
 <script>
     // Include analytics.js/tag-manager js here...
     
+    ga('create', '<trackingId>'); // New tracker instance
+    
     ga('set', 'expId', 'xyz'); ga('set', 'expVar', '2'); ga('send','pageview');
 </script>
 ```
 
-To reference GA's official documentation see:
+To reference GA's official documentation that describes how to send GA your experiment results see:
 https://developers.google.com/analytics/devguides/collection/analyticsjs/experiments#server-example
+
+To find your Tracking Id for your Tracker Instance see: https://support.google.com/analytics/answer/1008080?hl=en
 
 Important Note: _GA Content Experiments only supports tracking one experiment per page, and so the 
 getGoogleAnalyticsExperimentJsContent() method also assumes only one AB test is being ran per page.

--- a/src/Namshi/AB/GaExperimentTrait.php
+++ b/src/Namshi/AB/GaExperimentTrait.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: andrew
+ * Date: 2/9/17
+ * Time: 8:37 AM
+ */
+
+namespace Namshi\AB;
+
+/**
+ * Trait GaExperimentTrait
+ *
+ * Set the google experiment Id by using a parameter with a 'expId' key.
+ * Set google experiment variant id's by using parameters values with key names equal to the AbTest variant keys
+ * See https://developers.google.com/analytics/solutions/experiments-server-side#store-user for how to determine what
+ * the variation id's should be set to
+ *
+ * See https://developers.google.com/analytics/solutions/experiments-server-side for how to set up a server-side
+ * experiment through google analytics
+ *
+ * @package Namshi\AB
+ */
+trait GaExperimentTrait
+{
+
+    private static $googleAnalyticsExperimentId = '';
+    private static $googleAnalyticsExperimentVariant = '';
+
+
+    /**
+     * @return string
+     */
+    public static function getGoogleAnalyticsExperimentId()
+    {
+        return static::$googleAnalyticsExperimentId;
+    }
+
+    /**
+     * @param string $googleAnalyticsExperimentId
+     */
+    public static function setGoogleAnalyticsExperimentId($googleAnalyticsExperimentId)
+    {
+        static::$googleAnalyticsExperimentId = $googleAnalyticsExperimentId;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getGoogleAnalyticsExperimentVariant()
+    {
+        return static::$googleAnalyticsExperimentVariant;
+    }
+
+    /**
+     * @param string $googleAnalyticsExperimentVariant
+     */
+    public static function setGoogleAnalyticsExperimentVariant($googleAnalyticsExperimentVariant)
+    {
+        static::$googleAnalyticsExperimentVariant = $googleAnalyticsExperimentVariant;
+    }
+
+
+    /**
+     * Returns all Javascript needed to send a server-side experiment to google analytics
+     * Only dump this js data onto the page after analytics/tag manager has been initialized
+     *
+     * See https://developers.google.com/analytics/devguides/collection/analyticsjs/experiments#pro-server for more info
+     * See https://developers.google.com/analytics/devguides/collection/analyticsjs/experiments#server-example for example
+     * See https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#expId for API info
+     *
+     * @return string
+     */
+    public static function getGoogleAnalyticsExperimentJsContent()
+    {
+        if( static::getGoogleAnalyticsExperimentId() !== ''
+            && static::getGoogleAnalyticsExperimentVariant() !== ''
+        ) {
+            return "ga('set', 'expId', '".static::getGoogleAnalyticsExperimentId()."'); ga('set', 'expVar', '".static::getGoogleAnalyticsExperimentVariant()."'); ga('send','pageview');";
+        }
+
+        return '';
+    }
+
+}

--- a/src/Namshi/AB/Test.php
+++ b/src/Namshi/AB/Test.php
@@ -166,19 +166,16 @@ class Test implements Countable
         if ($this->isDisabled()) {
             $variations = array_keys($this->getVariations());
 
-            $variation = array_shift($variations);
-        }
-        else{
-            $variation = $this->variation;
+            return array_shift($variations);
         }
 
         // If the variant has a GA Experiment Variant Id
-        if($this->get($variation) !== NULL){
+        if($this->get($this->variation) !== NULL){
             // Set the Google Analytics Experiment Variant Id
-            static::setGoogleAnalyticsExperimentVariant($this->get($variation));
+            static::setGoogleAnalyticsExperimentVariant($this->get($this->variation));
         }
 
-        return $variation;
+        return $this->variation;
     }
     
     /**

--- a/tests/Namshi/AB/Test/GaExperimentTraitTest.php
+++ b/tests/Namshi/AB/Test/GaExperimentTraitTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: andrew
+ * Date: 2/9/17
+ * Time: 8:49 AM
+ */
+
+namespace Namshi\AB\Test;
+
+
+use Namshi\AB\GaExperimentTrait;
+
+
+class GaExperimentTraitTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @return GaExperimentTraitTest|Object
+     */
+    public function getTrait()
+    {
+        return $this->getObjectForTrait(GaExperimentTrait::class);
+    }
+
+    public function testGaExperimentIdAttribute()
+    {
+        $mock = $this->getTrait();
+        $mock::setGoogleAnalyticsExperimentId('abc');
+        $this->assertEquals('abc', $mock::getGoogleAnalyticsExperimentId());
+    }
+    public function testGaExperimentVariantAttribute()
+    {
+        $mock = $this->getTrait();
+        $mock::setGoogleAnalyticsExperimentVariant('5');
+        $this->assertEquals('5', $mock::getGoogleAnalyticsExperimentVariant());
+    }
+    public function testGaExperimentJs()
+    {
+        $mock = $this->getTrait();
+        $mock::setGoogleAnalyticsExperimentId('abc');
+        $mock::setGoogleAnalyticsExperimentVariant('5');
+        $this->assertEquals(
+            "ga('set', 'expId', 'abc'); ga('set', 'expVar', '5'); ga('send','pageview');",
+            $mock::getGoogleAnalyticsExperimentJsContent()
+        );
+    }
+    public function testGaExperimentJsWithNoSetup()
+    {
+        $mock = $this->getTrait();
+        $this->assertEquals(
+            "",
+            $mock::getGoogleAnalyticsExperimentJsContent()
+        );
+        $mock::setGoogleAnalyticsExperimentId('abc');
+        $this->assertEquals(
+            "",
+            $mock::getGoogleAnalyticsExperimentJsContent()
+        );
+        $mock::setGoogleAnalyticsExperimentId('');
+        $mock::setGoogleAnalyticsExperimentVariant('5');
+        $this->assertEquals(
+            "",
+            $mock::getGoogleAnalyticsExperimentJsContent()
+        );
+    }
+}

--- a/tests/Namshi/AB/Test/TestTest.php
+++ b/tests/Namshi/AB/Test/TestTest.php
@@ -7,7 +7,7 @@ use Namshi\AB\Test;
 class TestTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @return Namshi\AB\Test
+     * @return \Namshi\AB\Test
      */
     public function getTest($name = 'myTest', array $variations = array('a' => 0, 'b' => 1), array $parameters = array())
     {
@@ -171,5 +171,22 @@ class TestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($aProbability < 0.34);
         $this->assertTrue($bProbability > 0.66);
         $this->assertTrue($bProbability < 0.68);
+    }
+
+    public function testSettingGaExperimentId()
+    {
+        $test = $this->getTest('test', ['a'=>1,'b'=>1], ['expId'=>'xyz']);
+        $this->assertEquals('xyz',Test::getGoogleAnalyticsExperimentId());
+
+        Test::setGoogleAnalyticsExperimentId('123');
+        $this->assertEquals('123',Test::getGoogleAnalyticsExperimentId());
+    }
+
+    public function testSettingGaExperimentVariantId()
+    {
+        $params = ['a'=>0,'b'=>2];
+        $test = $this->getTest('test', ['a'=>1,'b'=>1], $params);
+        $variation = $test->getVariation();
+        $this->assertEquals($params[$variation],Test::getGoogleAnalyticsExperimentVariant());
     }
 }


### PR DESCRIPTION
I found your simple AB testing library to be just what I needed! The only thing missing was a similarly simple reporting mechanism. 

Since Google Analytics is perhaps one of the most widely used tool for tracking AB testing, I added a simple trait that allows your AB testing library to send it's results to a Google Analytics Experiment. To round out the new trait, I've added a couple of unit tests that verify the new functionality and updated the Readme.md file to outline how namshi/AB can be utilized to have Google Analytics monitor the AB testing results.

If you like the addition but something is not clear, please let me know. Thanks again for the great AB testing library!